### PR TITLE
Fix array_search not to evaluate 0 in export-html.php

### DIFF
--- a/bin/export-html.php
+++ b/bin/export-html.php
@@ -214,7 +214,7 @@ if (file_exists($lufile)) {
         foreach ($pi as $issue) {
             list($pkey,) = explode('-', $issue->key);
             if (count($allowedProjectKeys) == 0
-                || array_search($pkey, $allowedProjectKeys)
+                || array_search($pkey, $allowedProjectKeys) !== false
             ) {
                 $updatedProjects[$pkey] = true;
             }
@@ -306,7 +306,7 @@ function createProjectIndex($projects)
     $categories = array();
     foreach ($projects as $project) {
         if (count($allowedProjectKeys) != 0
-            && !array_search($project->key, $allowedProjectKeys)
+            && array_search($project->key, $allowedProjectKeys) === false
         ) {
             continue;
         }


### PR DESCRIPTION
The return value of array_search should be compared with false, consistently with here:

https://github.com/netresearch/jira-export/blob/master/bin/export-html.php#L240

That is because if the found index is 0, it is unexpectedly evaluated to false but true.

See also: https://stackoverflow.com/a/15934417